### PR TITLE
Use pregenerated DSA param to pass key size checks

### DIFF
--- a/certgen/certgen.mk
+++ b/certgen/certgen.mk
@@ -160,8 +160,8 @@ $(SERVER_CRT_EC): $(SERVER_CSR_EC) $(INTERMEDIATE_CRT) $(INTERMEDIATE_KEY)
 
 # generate server DSA param (fallback to pregenerated, needed in FIPS mode)
 $(SERVER_KEY_PARAM_DSA): | $(CERTGEN_BUILD_DIR)
-	openssl dsaparam -out $(SERVER_KEY_PARAM_DSA) $(DSA_KEY_SIZE) \
-	|| cp $(CERTGEN_DIR)/server-dsa.param $(SERVER_KEY_PARAM_DSA)
+	# openssl dsaparam -out $(SERVER_KEY_PARAM_DSA) $(DSA_KEY_SIZE)
+	cp $(CERTGEN_DIR)/server-dsa.param $(SERVER_KEY_PARAM_DSA)
 
 # generate server DSA key (fallback to pregenerated, needed in FIPS mode)
 $(SERVER_KEY_DSA): $(SERVER_KEY_PARAM_DSA) | $(CERTGEN_BUILD_DIR)


### PR DESCRIPTION
Legacy crypto-policies on Fedora allow for ciphers using DSA + SHA1.
DSA key used for testing must have these properties:
- have size >= 1024 bits (required by legacy cp)
- have Q <= 160 bits (to be usable with SHA1, see [check in DSA class](https://github.com/openjdk/jdk8u-dev/blob/3e69b49f71e1c00a4761a9e63440cb7af1216389/jdk/src/share/classes/sun/security/provider/DSA.java#L109))

Turns out key parameters generated for 1024 bit DSA key on recent Fedora do not satisfy both conditions. (causing test failures)
Fix is to always use pregenerated DSA params, not only as fallback.