### PR TITLE
Added workaround for ChaCha20-Poly1305 issue on ppc64le when nss fips provider is used

### DIFF
--- a/jtreg-wrappers/ssl-tests.sh
+++ b/jtreg-wrappers/ssl-tests.sh
@@ -7,4 +7,8 @@
 set -eu
 rm -rf build
 export JAVA_HOME="${TESTJAVA}"
+if uname -m | grep -q ppc64 ; then
+    # workaround for: https://bugzilla.redhat.com/show_bug.cgi?id=2164644
+    export NSS_DISABLE_PPC_GHASH=1
+fi
 make -f "${TESTSRC:-.}/../Makefile" ssl-tests TOP_DIR="${TESTSRC:-.}/.."


### PR DESCRIPTION
Workaround for nss problem in fips mode on ppc64le.
See:
https://bugzilla.redhat.com/show_bug.cgi?id=2164644