### PR TITLE
ssl-tests-nss-client.sh: skip on Alpine Linux

### DIFF
--- a/jtreg-wrappers/ssl-tests-nss-client.sh
+++ b/jtreg-wrappers/ssl-tests-nss-client.sh
@@ -8,6 +8,11 @@
 set -eu
 rm -rf build
 
+if grep -q 'Alpine' /etc/os-release > /dev/null 2>&1 ; then
+    echo "Skipping on Alpine, as it does not have required NSS tools"
+    exit 0
+fi
+
 if ! type listsuites > /dev/null 2>&1 \
 && ! [ -e "/usr/lib64/nss/unsupported-tools/listsuites" ] \
 && ! [ -e "/usr/lib/nss/unsupported-tools/listsuites" ] ; then


### PR DESCRIPTION
Configuration with NSS client is skiped on Alpine Linux, as it does not ship required nss tools.

See: https://github.com/adoptium/infrastructure/issues/3059#issuecomment-1687817213