### PR TITLE
Removed shutdown output workaround for gnutls client

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,7 +133,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.jdkver || env.jdkver_latest }}
       - name: Run
-        run: make ssl-tests SSLTESTS_USE_GNUTLS_CLIENT=1 SSLTESTS_SERVER_SHUTDOWN_OUTPUT=1
+        run: make ssl-tests SSLTESTS_USE_GNUTLS_CLIENT=1
 
   test-linux-nss-client:
     name: "Linux nss client"

--- a/jtreg-wrappers/ssl-tests-gnutls-client.sh
+++ b/jtreg-wrappers/ssl-tests-gnutls-client.sh
@@ -8,4 +8,4 @@
 set -eu
 rm -rf build
 export JAVA_HOME="${TESTJAVA}"
-make -f "${TESTSRC:-.}/../Makefile" ssl-tests TOP_DIR="${TESTSRC:-.}/.." SSLTESTS_SERVER_SHUTDOWN_OUTPUT=1 SSLTESTS_USE_GNUTLS_CLIENT=1
+make -f "${TESTSRC:-.}/../Makefile" ssl-tests TOP_DIR="${TESTSRC:-.}/.." SSLTESTS_USE_GNUTLS_CLIENT=1


### PR DESCRIPTION
This workaround using `SSLTESTS_SERVER_SHUTDOWN_OUTPUT` should no longer be necessary. It was workaround for issue in openjdk, fixed by  [JDK-8282600](https://bugs.openjdk.org/browse/JDK-8282600), which should now be in all JDKs.