### PR TITLE
Update GH testing to use jdk 21 as latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
     branches:
       - "*"
 env:
-  jdkver_latest: 20
+  jdkver_latest: 21
 
 jobs:
   test-linux:


### PR DESCRIPTION
Update GH testing to use jdk 21 as latest.