### PR TITLE
jtreg-wrappers: Add runtime check for native clients

### DIFF
--- a/jtreg-wrappers/SysDepsProps.java
+++ b/jtreg-wrappers/SysDepsProps.java
@@ -1,0 +1,89 @@
+import java.io.InputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.FileSystems;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.Callable;
+
+public class SysDepsProps implements Callable<Map<String, String>> {
+
+    Thread streamDiscarder(final InputStream is) {
+        return new Thread() {
+            @Override
+            public void run() {
+                try {
+                    try {
+                        while (is.read() >= 0) { /* discard */ };
+                    } finally {
+                        is.close();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+    }
+
+    boolean checkOnPath(String cmd) {
+        ProcessBuilder pb = new  ProcessBuilder(cmd, "--help");
+        Process p = null;
+        Thread outDiscarder = null;
+        Thread errDiscarder = null;
+        int retVal = 0;
+        try {
+            p = pb.start(); // throws exception if program does not exist
+            outDiscarder = streamDiscarder(p.getInputStream());
+            outDiscarder.start();
+            errDiscarder = streamDiscarder(p.getErrorStream());
+            errDiscarder.start();
+            p.getOutputStream().close();
+            p.waitFor();
+            return true;
+        } catch (Exception ex) {
+            if (p != null) {
+                p.destroy();
+            }
+        } finally {
+            try {
+                if (outDiscarder != null) {
+                    outDiscarder.join();
+                }
+                if (errDiscarder != null) {
+                    errDiscarder.join();
+                }
+            } catch (InterruptedException ex) {}
+        }
+        return false;
+    }
+
+    boolean fileExists(String path) {
+        return Files.exists(FileSystems.getDefault().getPath(path));
+    }
+
+    boolean checkGnutlsCli() {
+        return checkOnPath("gnutls-cli");
+    }
+
+    boolean checkTstclnt() {
+        if (fileExists("/usr/lib64/nss/unsupported-tools/tstclnt")
+            || fileExists("/usr/lib/nss/unsupported-tools/tstclnt")) {
+            return true;
+        }
+        return checkOnPath("tstclnt");
+    }
+
+    @Override
+    public Map<String, String> call() {
+        Map<String, String> map = new HashMap<String, String>();
+        map.put("bin.gnutlscli", checkGnutlsCli() ? "true": "false");
+        map.put("bin.tstclnt", checkTstclnt() ? "true": "false");
+        return map;
+    }
+
+    public static void main(String[] args) {
+        for (Map.Entry<String,String> entry: new SysDepsProps().call().entrySet()) {
+            System.out.println(entry.getKey() + ": " + entry.getValue());
+        }
+    }
+}

--- a/jtreg-wrappers/TEST.ROOT
+++ b/jtreg-wrappers/TEST.ROOT
@@ -1,0 +1,4 @@
+requires.extraPropDefns = SysDepsProps.java
+requires.properties = \
+    bin.gnutlscli \
+    bin.tstclnt

--- a/jtreg-wrappers/ssl-tests-gnutls-client.sh
+++ b/jtreg-wrappers/ssl-tests-gnutls-client.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # @test
-# @requires os.family == "linux"
+# @requires os.family == "linux" & bin.gnutlscli != "false"
 # @bug 6666666
 # @summary ssl-tests with gnutls client
 # @run shell/timeout=1000 ssl-tests-gnutls-client.sh

--- a/jtreg-wrappers/ssl-tests-nss-client.sh
+++ b/jtreg-wrappers/ssl-tests-nss-client.sh
@@ -1,25 +1,12 @@
 #!/bin/sh
 # @test
-# @requires os.family == "linux"
+# @requires os.family == "linux" & bin.tstclnt != "false"
 # @bug 6666666
 # @summary ssl-test with nss client
 # @run shell/timeout=1000 ssl-tests-nss-client.sh
 
 set -eu
 rm -rf build
-
-if ! type tstclnt > /dev/null 2>&1 \
-&& ! [ -e "/usr/lib64/nss/unsupported-tools/tstclnt" ] \
-&& ! [ -e "/usr/lib/nss/unsupported-tools/tstclnt" ] ; then
-    if grep -Eiq 'Fedora|Red Hat|Ubuntu' /etc/os-release > /dev/null 2>&1 ; then
-        # Error on system, where it should be available
-        echo "Error: Missing tstclnt tool, please install NSS tools"
-        exit 1
-    else
-        echo "Skipping, required tstclnt tool not found"
-        exit 0
-    fi
-fi
 
 if ! type listsuites > /dev/null 2>&1 \
 && ! [ -e "/usr/lib64/nss/unsupported-tools/listsuites" ] \


### PR DESCRIPTION
This introduces custom jtreg properties, which track presence of native clients. Test can use them in `@requires`, so they are excluded, when native client is missing.