### PR TITLE
jtreg-wrappers: Limit BC test variants to linux and windows

### DIFF
--- a/jtreg-wrappers/ssl-tests-bc-2nd.sh
+++ b/jtreg-wrappers/ssl-tests-bc-2nd.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # @test
 # @bug 6666666
+# @requires os.family == "linux" | os.family == "windows"
 # @summary ssl-test-bc with BouncyCastle provider (BC_2ND configuration)
 # @run shell/timeout=1000 ssl-tests-bc-2nd.sh
 

--- a/jtreg-wrappers/ssl-tests-bcfips.sh
+++ b/jtreg-wrappers/ssl-tests-bcfips.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # @test
 # @bug 6666666
-# @requires jdk.version.major <= 11
+# @requires jdk.version.major <= 11 & ( os.family == "linux" | os.family == "windows" )
 # @summary ssl-test-bc with BouncyCastle provider (BCFIPS configuration)
 # @run shell/timeout=4000 ssl-tests-bcfips.sh
 

--- a/jtreg-wrappers/ssl-tests-bcjsse.sh
+++ b/jtreg-wrappers/ssl-tests-bcjsse.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # @test
 # @bug 6666666
+# @requires os.family == "linux" | os.family == "windows"
 # @summary ssl-tests with BouncyCastle provider (BCJSSE configuration)
 # @run shell/timeout=1000 ssl-tests-bcjsse.sh
 


### PR DESCRIPTION
Even with [sed fix](https://github.com/rh-openjdk/ssl-tests/pull/17), there is still some other problem (exception) on MacOS in BC (BouncyCastle) variant:
```
Error: Exception in thread "main" java.io.IOException: keystore password was incorrect
	at java.base/sun.security.pkcs12.PKCS12KeyStore.engineLoad(PKCS12KeyStore.java:2116)
	at java.base/sun.security.util.KeyStoreDelegator.engineLoad(KeyStoreDelegator.java:222)
	at java.base/java.security.KeyStore.load(KeyStore.java:1479)
	at SSLSocketTester.loadKeystore(SSLSocketTester.java:148)
	at SSLSocketTester.getKeyManagers(SSLSocketTester.java:123)
	at SSLSocketTester.init(SSLSocketTester.java:94)
	at Main.main(Main.java:29)
Caused by: java.security.UnrecoverableKeyException: failed to decrypt safe contents entry: javax.crypto.BadPaddingException: Given final block not properly padded. Such issues can arise if a bad key is used during decryption.
	... 7 more
```

As debugging problems with only GHA, without access to physical machine, is clumsy and time consuming, I am not going to dig into it right now and rather limit jtreg-wrappers to run BC variants only on Linux and Windows. Jtreg-wrappers still run ssl-tests in basic configuration on MacOS.