### PR TITLE
Limit jtreg wrappers only to linux windows and mac

### DIFF
--- a/jtreg-wrappers/ssl-tests.sh
+++ b/jtreg-wrappers/ssl-tests.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # @test
 # @bug 6666666
+# @requires os.family == "linux" | os.family == "windows" | os.family == "mac"
 # @summary ssl-tests
 # @run shell/timeout=1000 ssl-tests.sh
 


### PR DESCRIPTION
Limit last unrestricted jtreg wrapper to run only on linux, windows and MacOS. There are some problem on [exotic OSes](https://github.com/rh-openjdk/ssl-tests/issues/20), but I have no good means to debug them or to test them automatically in GH...