### PR TITLE
disable mac ojdk8 GH actions recipes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,13 +55,10 @@ jobs:
       fail-fast: false
       matrix:
         jdkconf:
-          - JDK 8
           - JDK 11
           - JDK 17
           - JDK 21
         include:
-          - jdkconf: JDK 8
-            jdkver: "8"
           - jdkconf: JDK 11
             jdkver: "11"
           - jdkconf: JDK 17
@@ -477,13 +474,10 @@ jobs:
       fail-fast: false
       matrix:
         jdkconf:
-          - JDK 8
           - JDK 11
           - JDK 17
           - JDK 21
         include:
-          - jdkconf: JDK 8
-            jdkver: "8"
           - jdkconf: JDK 11
             jdkver: "11"
           - jdkconf: JDK 17


### PR DESCRIPTION
SSIA, ojdk8 macs are failing, as they are not to be found any more https://github.com/rh-openjdk/ssl-tests/actions/runs/11725732368/job/32662745223?pr=31