### PR TITLE
OpensslClient.java: fixed crypto-policies detection

### DIFF
--- a/ssl-tests/src/OpensslClient.java
+++ b/ssl-tests/src/OpensslClient.java
@@ -117,7 +117,8 @@ public class OpensslClient extends ExternalClient {
         }
         String name;
         Path path = FileSystems.getDefault().getPath("/etc/crypto-policies/back-ends/openssl.config");
-        if (Files.exists(path)) {
+        Path path2 = FileSystems.getDefault().getPath("/etc/crypto-policies/back-ends/opensslcnf.config");
+        if (Files.exists(path) || Files.exists(path2)) {
             /* Ciphers enabled by current system crypto policy */
             name="PROFILE=SYSTEM";
         } else {


### PR DESCRIPTION
Fixed crypto policies detection after [dropping openssl.config](https://gitlab.com/redhat/centos-stream/rpms/crypto-policies/-/commit/1916ddf23859903988e23c3db9c1f78c0dfcbd11).